### PR TITLE
Switch to correct branches for ROS 2

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -67,7 +67,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
-    devel_branch: ros2
+    devel_branch: humble
     last_version: 0.3.6
     name: geometry_tutorials
     patches: null
@@ -137,7 +137,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
-    devel_branch: ros2
+    devel_branch: iron
     last_version: 0.3.6
     name: geometry_tutorials
     patches: null
@@ -185,7 +185,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
-    devel_branch: ros2
+    devel_branch: jazzy
     last_version: 0.3.6
     name: geometry_tutorials
     patches: null
@@ -307,7 +307,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
-    devel_branch: ros2
+    devel_branch: rolling
     last_version: 0.3.6
     name: geometry_tutorials
     patches: null


### PR DESCRIPTION
FYI @ahcorde .  To make this really work properly, my suggestion is to:

1.  Merge this PR.
2.  Merge in https://github.com/ros/ros_tutorials/pull/169 , https://github.com/ros/geometry_tutorials/pull/78 , and https://github.com/ros2/ros2_documentation/pull/4562
3.  Do a release of geometry_tutorials into Rolling as version 0.6.0.
4.  Do a release of geometry_tutorials into Jazzy as version 0.5.0.
5.  Do a release of geometry_tutorials into Iron as version 0.4.0.
6.  Do a release of geometry_tutorials into Humble as version 0.3.7.